### PR TITLE
Clarify changelog dates from March-July 2024

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -225,7 +225,7 @@ You can now specify a custom SQL sampling query for offline queries. This allows
 to compute the query's entity spine for offline queries. This is useful when you have a complicated sampling policy
 (i.e. class-based sampling). Additional non-primary key features can be provided as well.
 
-## Jan 22, 2024
+## January 22, 2024
 
 ### `required_resolver_tags` for queries
 
@@ -268,7 +268,7 @@ dataset = ChalkClient().offline_query(
 )
 ```
 
-## October 24th, 2023
+## October 24, 2023
 
 ### Support for Python 3.11
 
@@ -287,7 +287,7 @@ See [Python Version](/docs/docker#python-version) for more information.
 
 ---
 
-## October 23rd, 2023
+## October 23, 2023
 
 ### Quality of Life Improvements
 
@@ -296,7 +296,7 @@ be defined as Python classes, and string names for inputs and outputs can now be
 
 ---
 
-## October 11th, 2023
+## October 11, 2023
 
 ### Alert descriptions
 
@@ -323,7 +323,7 @@ These descriptions can also be set in the Chalk dashboard via the metric alerts 
 
 ---
 
-## October 5th, 2023
+## October 5, 2023
 
 ### `query_bulk` support for notebooks
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,14 +5,15 @@ description: Updates to Chalk!
 
 ---
 
-## July 1, 2024
+## July 10, 2024
 
 ### Feature Catalog
 
-We are in the process of making updates to the feature catalog. You can now view and filter features
-in the feature catalog by their tags and owners.
+You can now view and filter features in the feature catalog by their tags and owners.
 
 ![Feature catalog filtering by tag and owner](/img/feature_catalog_tag_owner.png)
+
+## July 1, 2024
 
 ### Chalk gRPC
 
@@ -72,6 +73,8 @@ class SampleFeatureSet:
     feature_1_2_equality: bool = _.feature_1 == _.feature_2
 ```
 
+## June 28, 2024
+
 ### Chalk deployment tags
 
 You can now add tags to your deployments. Tags must be unique to each of your environments. If you add an already existing tag to a new deployment, Chalk will remove the tag from your old deployment.
@@ -90,6 +93,22 @@ values that aren't set, and allows you to easily adjust your cluster's resources
 
 ![resource configuration management](/img/cloud-resource-config.png)
 
+## June 19, 2024
+
+### New data sources and native drivers
+
+We added integrations for Trino and Spanner as new data sources. We've also added native drivers for Postgres and
+Spanner, which drastically improves performance for these data sources.
+
+## May 29, 2024
+
+### Heartbeating
+
+We now have heartbeating to poll the status of long-running queries and resolvers, which will now mark any hanging
+runs that are no longer detected as "failed" after a certain period of time.
+
+## May 14, 2024
+
 ### Data source and feature-level RBAC
 
 We expanded the functionality of our service tokens to enable role-based access control (RBAC) at both the
@@ -100,15 +119,7 @@ used in the computation of other features, or by blocking the token from accessi
 
 ![datasource and feature level rbac](/img/datasource-feature-rbac.png)
 
-### New data sources and native drivers
-
-We added integrations for Trino and Spanner as new data sources. We've also added native drivers for Postgres and
-Spanner, which drastically improves performance for these data sources.
-
-### Heartbeating
-
-We now have heartbeating to poll the status of long-running queries and resolvers, which will now mark any hanging
-runs that are no longer detected as "failed" after a certain period of time.
+## May 8, 2024
 
 ### Incremental Status
 
@@ -125,16 +136,27 @@ Max Ingested Timestamp:   2024-07-01T16:01:46+00:00
 Last Execution Timestamp: 2024-07-01T00:01:27.421873+00:00
 ````
 
-### Miscellaneous improvements
-* In addition to the changes listed above, we also shipped a number of smaller improvements including but not
-limited to:
-    * spellcheck (based on Levenshtein distance) in SQL file resolvers
-    * type errors on failed annotation parsing
-    * improved errors for failure in type conversion in SQL resolvers (eg. your SQL file resolver selects an int column
-    but the feature is defined as a string)
-    * windowed resolvers have expanded to allow for hourly cadences.
+## April 18, 2024
 
-## Mar 19, 2024
+### Miscellaneous improvements
+
+* Windowed resolvers have expanded to allow for hourly cadences.
+
+## April 9, 2024
+
+### Miscellaneous improvements
+
+* SQL resolvers have improved error reporting for failures related to type conversion (e.g., if your resolver selects
+  an int column, but the feature's type is string)
+
+## March 29, 2024
+
+### Miscellaneous improvements
+
+* SQL file resolvers have spellcheck (based on Levenshtein distance)
+* Failed annotation parsing raises a type error with a more helpful error message
+
+## March 19, 2024
 
 ### Scheduled Queries
 
@@ -181,7 +203,7 @@ This is useful when you have a large number of features that you want to recompu
 - Dataset downloads no longer have any dependency on locally registered features, which resolves crashes for certain dataset management workflows.
 - `ChalkClient.query` now supports `request_timeout: float`, which is passed to the underlying `requests.request` call.
 
-## Mar 8, 2024
+## March 8, 2024
 
 ### Bugfixes and improvements
 
@@ -195,7 +217,7 @@ it was possible to get into a state that was impossible to recover from without 
 prevents the user from accidentally using a dataset that was not computed correctly. If you wish to use the dataset
 anyway, you can use `DataSet.to_polars(ignore_errors=True)`.
 
-## Mar 1 2024
+## March 1, 2024
 
 ### Support for custom SQL sampling in offline query
 


### PR DESCRIPTION
The changelog entry from July 1 actually covered work from March to July. This PR breaks down the dates so that it's clear when each change really shipped.

I found these dates by searching our github history!