### PR TITLE
fix language in changelog, fix unrendered url

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -17,10 +17,9 @@ You can now view and filter features in the feature catalog by their tags and ow
 
 ### Chalk gRPC
 
-We shipped a gRPC engine for Chalk that drastically improves performance by **at least 2x** through improved data
-serialization, efficient data transfer, and a migration from Python to Go and C++. You can now use the ChalkGRPCClient
-to run queries with the GRPC engine, and fetch enriched metadata about your feature sets and resolvers through the
-`get_graph` method.
+We shipped a gRPC engine for Chalk that improved performance by at least 2x through improved data serialization,
+efficient data transfer, and a migration to our C++ server. You can now use `ChalkGRPCClient` to run queries with the
+gRPC engine and fetch enriched metadata about your feature sets and resolvers through the `get_graph` method.
 
 ### Spine SQL query
 

--- a/training-client.mdx
+++ b/training-client.mdx
@@ -90,10 +90,8 @@ each referenced feature namespace, the feature namespace's primary key must be i
 Chalk replaces `__` in column names with `.` to form Chalk feature names. For example, `seller__id` corresponds to the
 `Seller.id` feature.
 
-<TipInfo>
-    The "ts" column is always interpreted as the query execution time for the row. See our documentation on [temporal
-    consistency](/docs/temporal-consistency) for more details.
-</TipInfo>
+The "ts" column is always interpreted as the query execution time for the row. See our documentation on [temporal
+consistency](/docs/temporal-consistency) for more details.
 
 ```python
 output = chalk_client.query(


### PR DESCRIPTION
1. Make the changelog language match the upcoming blog post
2. TipInfo currently doesn't render URLs. For expediency, I deleted the TipInfo. I'll think about revising later.