### PR TITLE
polish query overview page, add namespace info

### DIFF
--- a/query-overview.mdx
+++ b/query-overview.mdx
@@ -6,7 +6,7 @@ description: Fetch feature values via queries.
 ---
 
 To request or compute data with Chalk, you'll use **queries**. In general,
-when you run a Chalk query, you are either: requesting the most up-to-date
+when you run a Chalk query, you are either requesting the most up-to-date
 values for your feature sets, requesting a set of historical data
 for your feature sets, or running a backfill or batch job.
 
@@ -14,77 +14,18 @@ The first use case is accomplished through **online queries**, which try to
 return values for a single feature set as quickly as possible, taking
 advantage of caching and distributed execution.
 
-The latter use cases are accomplished through offline queries which execute
-over the offline store and can return multiple instances of a feature set
+The latter use cases are accomplished through **offline queries** which use 
+the offline store and can return multiple instances of a feature set
 for multiple primary keys or timepoints.
 
-## What are Queries
+## Running queries
 
-At a high level, a query specifies input features and output features.
-Inputs differ slightly for online queries and offline queries, but in both
-cases the input must contain the primary key of your requested feature set.
+At a high level, a query specifies input features and output features. Inputs differ slightly for online queries and
+offline queries, but in both cases the input must contain the primary key of your requested feature set.
 
-For example, for an online query, the input could be the id of a user for
-which you want to compute output features. You can also specify additional
-features that "overwrite" the features your resolver would otherwise compute.
-For instance, you could run an online query passing one of your user's ids but also
-a hard coded name. Using Chalk's CLI, this would look like the following:
+### Running online queries
 
-```sh
-chalk query --in user.id=1 --in user.name=mary --out user
-```
-
-For offline queries, the input is a list of ids for one of your feature
-sets and, optionally, any number of lists containing values for any other
-feature from the same namespace.
-
-Online and offline queries differ most in their output. An online
-query only ever returns one value for each requested output feature, which
-it retrieves either from the cache or by executing resolvers.
-
-An offline query returns all requested computed features for all requested ids.
-For instance, say you've computed the number of transactions (`num_transactions`)
-for a User with id 1 every day over the past week. Making an offline query
-with `user.id=1` as an input and `user.num_transactions` as an output would
-return all seven of the previously computed values for `num_transactions`.
-
-Offline queries are often restricted by lower and upper bound timestamps
-which constrain the outputs to a specific temporal range.
-
-## Query Side Effects
-
-Chalk queries can also write data. This is an essential part of
-Chalk: every time you compute a feature through an online query the
-output is written down in the offline store. This makes it easy to:
-
-- create datasets from your previously computed features,
-- monitor and track your computed features over time.
-
-Though not the default, offline queries can also write data to the
-offline store and the online store—this can be useful when backfilling
-data from slow data sources or when performing expensive feature computation that
-would otherwise significantly impact the latency of your online queries.
-
-| Online query                                                                                                                  | Offline query                                                                                                                                                                                                                                |
-|-------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Runs only <code className="whitespace-nowrap before:content-none text-pink-400 after:content-none"> @online </code> resolvers | Runs both <code className="whitespace-nowrap before:content-none text-pink-400 after:content-none"> @online </code> and <code className="whitespace-nowrap before:content-none text-pink-400 after:content-none"> @offline </code> resolvers |
-| Returns one row of data about one entity                                                                                      | Returns a DataFrame of many rows of historical data corresponding to multiple entities point-in-time                                                                                                                                         |
-| Designed to return data in milliseconds                                                                           | Blocks until computation is complete, not designed for millisecond-level computation                                                                                                                                                         |
-| Queries the online store and calls `@online` resolvers for quick retrieval                                                      | Queries the offline store which stores all data from online queries, unless `recompute_features=True` in which case `@offline` and `@online` resolvers are used to resolve the outputs
-| Writes output data to online store database and offline store database                                                        | Writes output to a parquet file containing results to cloud storage. Only writes to online store or offline store if specified.
-
-
----
-
-## Running Queries
-
-Queries are executed against deployments or branches. The easiest way to execute
-a query is either: 1). with the Chalk CLI, or 2). with one of Chalk's API
-clients.
-
-### Running Online Queries
-
-Online Queries can be run using the chalk CLI:
+Online queries can be run using [query](/cli/query):
 
 ```bash
 chalk query --in user.id=1 --out user.name
@@ -97,15 +38,15 @@ from chalk.client import ChalkClient
 
 client = ChalkClient()
 client.query(
-  inputy={'user.id': 1},
+  input={'user.id': 1},
   output=['user.name'],
   # branch='test', # run against a branch
 )
 ```
 
-### Running Offline Queries
+### Running offline queries
 
-Offline Queries can be run with one of our API Clients.
+Offline queries can be run with one of our API Clients:
 
 ```python
 from chalk.client import ChalkClient
@@ -124,8 +65,35 @@ client.offline_query(
 )
 ```
 
-### Scheduled and Triggered Resolver Run
+### Scheduled and triggered resolver runs
 
-Specific resolvers can also be [scheduled](/docs/resolver-cron) or [triggered](/docs/runs) (for instance as part of engineering pipelines like airflow).
-Specific queries can [also be scheduled](/docs/changelog#scheduled-queries). Functionally, triggers and schedules are effective ways of pulling data from
-"slow" data sources into your offline and online store.
+Specific resolvers can also be [scheduled](/docs/resolver-cron) or [triggered](/docs/runs) (for instance, as part of
+pipelines like Airflow). Specific queries can also be scheduled with
+[`ScheduledQuery`](/api-docs#ScheduledQuery). Triggers and schedules are useful for pulling data from "slow" data
+sources into your offline and online store.
+
+## Query side effects
+
+Chalk queries can also write data. This is an essential part of
+Chalk: every time you compute a feature through an online query, the
+output is written down in the offline store. This makes it easy to:
+
+- create datasets from your previously computed features,
+- monitor and track your computed features over time.
+
+Though not the default, offline queries can write data to both the offline store and the online store using
+[`etl_offline_to_online`](/api-docs#features.etl_offline_to_online). This can be useful when backfilling data from slow
+data sources or when performing expensive feature computation that would otherwise significantly impact the latency of
+your online queries.
+
+## Online and offline query differences
+
+| Online query | Offline query |
+|---|---|
+| Runs only <code className="whitespace-nowrap before:content-none text-pink-400 after:content-none"> @online </code> resolvers | Runs both <code className="whitespace-nowrap before:content-none text-pink-400 after:content-none"> @online </code> and <code className="whitespace-nowrap before:content-none text-pink-400 after:content-none"> @offline </code> resolvers |
+| Returns one row of data about one entity | Returns a DataFrame of many rows of historical data corresponding to multiple entities point-in-time |
+| Designed to return data in milliseconds | Blocks until computation is complete, not designed for millisecond-level computation |
+| Queries the online store and calls `@online` resolvers for quick retrieval | Queries the offline store which stores all data from online queries, unless `recompute_features=True`, in which case `@offline` and `@online` resolvers are used to resolve the outputs |
+| Writes output data to online store database and offline store database | Writes output to a parquet file containing results to cloud storage. Only writes to online store or offline store if specified. |
+| Can query multiple namespaces per query | Can only query one namespace per query |
+


### PR DESCRIPTION
- controversial take: I deleted the entire "what are queries" section because it's repetitive with the rest of the doc
- I modified the order of sections

old:

![image](https://github.com/user-attachments/assets/2581f816-1749-4375-b306-6e0a67a235fb)

new:

![image](https://github.com/user-attachments/assets/728330ee-ff52-48f0-b8fc-028a48a851e0)
- I lost my mind over the unnecessary whitespace in the markdown table
- I added "Can query multiple namespaces per query" to the online vs offline differences table