### PR TITLE
pin python version for `brew` instructions

### DIFF
--- a/setup-guide.mdx
+++ b/setup-guide.mdx
@@ -24,8 +24,8 @@ directory.
 ```bash Terminal
 # Install Homebrew
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-# Use Homebrew to install python3
-$ brew install python
+# Use Homebrew to install python3.11
+$ brew install python@3.11
 ```
 3. Install the [Chalk command line tool](/cli/). The Chalk CLI allows you to create, update, and
 manage your feature pipelines directly from your terminal
@@ -34,7 +34,7 @@ curl -s -L https://api.chalk.ai/install.sh | sh
 ```
 4. Create a Python virtual environment within your repository root directory and activate it
 ```bash
-$ python3.10 -m venv .venv
+$ python3.11 -m venv .venv
 $ source .venv/bin/activate
 ```
 You can run `source .venv/bin/activate` to activate the virtual environment, and `deactivate` to deactivate.
@@ -58,7 +58,7 @@ contains the following
    environments:
      default:
        requirements: requirements.txt
-       runtime: python310
+       runtime: python311
    ```
 
 The second file, `README.md`, contains some basic commands you can use with the Chalk CLI.


### PR DESCRIPTION
While running through the getting started docs I noticed the following brew command:

```
brew install python
```

unfortunately, as of today that will default to Python 3.13. This version will fail when one then attempts to download and install all the required dependencies using `pip`. I tested the install on 3.11 and 3.12 and there is no issue.

I also noticed a bit of drift between the generated `chalk.yaml` file and the docs. The `chalk init` now generates a yaml with `python311` and no longer `python310`.

This PR suggests editing the instructions so that the user downloads Python 3.11 specifically. This way everything aligns and the new user won't hit any gotchas.