### PR TITLE
docs patch: bunch of v tiny typos

### DIFF
--- a/background-persistence-installation.mdx
+++ b/background-persistence-installation.mdx
@@ -9,7 +9,7 @@ import {
 } from '@/components/AttributeTable'
 
 ---
-Chalk uses background writers hosted in the ("Customer Cloud") kubernetes cluster
+Chalk uses background writers hosted in the ("Customer Cloud") Kubernetes cluster
 to write information about queries to various storage locations.
 
 ## Prerequisites
@@ -35,8 +35,8 @@ you will see a message indicating that no background persistence is currently pr
 first save and apply will create background persistence writers.
 
 ## Pubsub vs Kafka
-When using pubsub, topics and subscriptions are 2 separate entities, but for kafka, we use the same
-topic for both publishing and subscribing. Additionally, we need to provide kafka authentication
+When using pubsub, topics and subscriptions are 2 separate entities, but for Kafka, we use the same
+topic for both publishing and subscribing. Additionally, we need to provide Kafka authentication
 credential, whereas pubsub uses its google identity to authenticate.
 
 ## Configuration Options (Common)
@@ -80,7 +80,7 @@ The Kafka security protocol to use.
 The Kafka SASL mechanism to use.
 </Attribute>
 <Attribute field={'redis_is_clustered'} kind={'string'}>
-Whether Redis is clustered or not, if using a redis online store.
+Whether Redis is clustered or not, if using a Redis online store.
 </Attribute>
 <Attribute field={'snowflake_storage_integration_name'} kind={'string'}>
 The name of the Snowflake storage integration.

--- a/bigquery-export.mdx
+++ b/bigquery-export.mdx
@@ -1,6 +1,6 @@
 ---
-title: Bigquery Export
-description: Configuration for feature export to Bigquery
+title: BigQuery Export
+description: Configuration for feature export to BigQuery
 ---
 
 

--- a/env-vars.mdx
+++ b/env-vars.mdx
@@ -46,5 +46,5 @@ can use in your resolvers.
 | `CHALK_DEPLOYMENT_ID`      | The ID of the deployment                                                                              |
 | `CHALK_TEAM_ID`            | The ID of the team                                                                                    |
 | `CHALK_PROJECT_ID`         | The ID of the project                                                                                 |
-| `CHALK_ACTIVE_ENVIRONMENT` | The id of the active environment (eg. `"9d0oj902"`)                                                   |
-| `CHALK_ENVIRONMENT_NAME`   | The name of the active environment (eg. `"prod"`)                                                     |
+| `CHALK_ACTIVE_ENVIRONMENT` | The id of the active environment (e.g. `"9d0oj902"`)                                                   |
+| `CHALK_ENVIRONMENT_NAME`   | The name of the active environment (e.g. `"prod"`)                                                     |

--- a/envoy-gateway-installation.mdx
+++ b/envoy-gateway-installation.mdx
@@ -37,13 +37,13 @@ first save and apply will create a new gateway.
 
 ## Configuration Options
 
-See documentation from kubernetes on [the gateway class ](https://gateway-api.sigs.k8s.io/api-types/gatewayclass/)
+See documentation from Kubernetes on [the gateway class ](https://gateway-api.sigs.k8s.io/api-types/gatewayclass/)
 for more information about the gateway.
 
 <AttributeTable>
 
   <Attribute field={"namespace"} kind={"string"}>
-    The kubernetes namespace this gateway should be deployed in.
+    The Kubernetes namespace this gateway should be deployed in.
   </Attribute>
   <Attribute field={"gateway_name"} kind={"string"}>
     A name to attach to this gateway.
@@ -60,7 +60,7 @@ for more information about the gateway.
 ### Listener
 
 This is the scheme for individual listener objects. For more information about allowed routes, refer to the
-[kubernetes documentation](https://registry.terraform.io/providers/metio/k8s/latest/docs/data-sources/gateway_networking_k8s_io_gateway_v1beta1_manifest#allowed_routes) on allowed syntax:
+[Kubernetes documentation](https://registry.terraform.io/providers/metio/k8s/latest/docs/data-sources/gateway_networking_k8s_io_gateway_v1beta1_manifest#allowed_routes) on allowed syntax:
 
 <AttributeTable>
   <Attribute field={"name"} kind={"string"}>

--- a/fraud-2.mdx
+++ b/fraud-2.mdx
@@ -72,7 +72,7 @@ class User:
 In our features below, we've added some comments and
 annotations to our features. These are optional, but
 can be useful for documentation and for setting alerting
-policies. For example, you may wish to send [Pagerduty alerts](/docs/pagerduty)
+policies. For example, you may wish to send [PagerDuty alerts](/docs/pagerduty)
 to [different teams](/docs/alertconfig) based on
 the owner of the related feature.
 

--- a/fraud-3.mdx
+++ b/fraud-3.mdx
@@ -221,7 +221,7 @@ class Account:
 +   updated_at: FeatureTime
 ```
 
-Features with overriden observation timestamps are inserted into
+Features with overridden observation timestamps are inserted into
 the offline store with the timestamp that you
 specify. The observation timestamp works like an "effective as of" timestamp.
 When you sample historical data, you can specify the observation timestamp

--- a/metrics-installation.mdx
+++ b/metrics-installation.mdx
@@ -9,7 +9,7 @@ import {
 } from '@/components/AttributeTable'
 
 ---
-Chalk uses a database hosted in the ("Customer Cloud") kubernetes cluster
+Chalk uses a database hosted in the ("Customer Cloud") Kubernetes cluster
 to store metrics data. This database is part of the environment dataplane,
 and stores information and metrics about queries run in a Chalk environment.
 

--- a/observability.mdx
+++ b/observability.mdx
@@ -28,7 +28,7 @@ Resolvers support many workflows and common orchestration patterns:
   Export Chalk logs to other monitoring systems.
 - **[Datadog Integration](/docs/datadog)** -
   Ingest Chalk metrics into Datadog.
-- **[Pagerduty](/docs/pagerduty)** -
-  Integrate Pagerduty alerts into you feature pipelines.
+- **[PagerDuty](/docs/pagerduty)** -
+  Integrate PagerDuty alerts into you feature pipelines.
 - **[Slack](/docs/slack)** -
   Consume Chalk alerts in your Slack channels.

--- a/on-prem-gcp.mdx
+++ b/on-prem-gcp.mdx
@@ -39,7 +39,7 @@ resources that must be provisioned.
 - **Google Secret Manager**: Chalk requires access to [Google Secret Manager](https://cloud.google.com/secret-manager) to store user-provided datasource credentials that are used by the Chalk Compute Cluster to communicate with your underlying datasources.
 - **Google Pubsub**: Chalk uses [Google Pubsub](https://cloud.google.com/pubsub) in order to persist data from the compute server to online and offline storage.
 - **Google Cloud Scheduler**: Chalk uses [Google Cloud Scheduler](https://cloud.google.com/scheduler) in order to coordinate offline feature derivation jobs.
-- **Google Cloud Build**: Chalk uses [Google Gloud Build](https://cloud.google.com/build) in order to construct Docker images containing your feature engineering pipelines.
+- **Google Cloud Build**: Chalk uses [Google Cloud Build](https://cloud.google.com/build) in order to construct Docker images containing your feature engineering pipelines.
 - **Google Cloud Storage**: Chalk uses [Google Cloud Storage](https://cloud.google.com/storage) to store computed datasets and for bulk upload jobs into the BigQuery offline store.
 
 ## Kubernetes Resources

--- a/query-basics.mdx
+++ b/query-basics.mdx
@@ -59,7 +59,7 @@ Read more about the parameters to this method [here](/api-docs#ChalkClient.query
   Input features and values are provided at the time of request.
   For example, primary key-value pairs often designate the subset of data returned. Feature inputs
   are provided by fully qualified path.  <a href={'/docs/has-many'}>Has many features</a>
-  are input as lists, and <a href={'/docs/feature-types#dataclass'}>struct features</a> are input as Json.
+  are input as lists, and <a href={'/docs/feature-types#dataclass'}>struct features</a> are input as JSON.
 
   An example of passing a user with two credit cards as input:
   ```{user.id: '1', user.cards: [card.id: 'xyz', card.id:'abc']}```

--- a/setup-guide.mdx
+++ b/setup-guide.mdx
@@ -86,7 +86,7 @@ which we will build in the next step.
 Having set up a basic project directory, next we'll want to configure the data sources from which we will load data to
 compute our features. We can do so in the Chalk dashboard.
 
-1. In the same directory from before, login or signup with Chalk directly from the command line. The
+1. In the same directory from before, login or sign up with Chalk directly from the command line. The
 [`chalk login`](/cli/login) command will open your browser and create an
 API token for your local development, as well as redirect you to your dashboard. If you are not
 redirected you can also find the dashboard at [https://chalk.ai/projects](https://chalk.ai/projects)

--- a/setup-guide.mdx
+++ b/setup-guide.mdx
@@ -39,8 +39,8 @@ $ source .venv/bin/activate
 ```
 You can run `source .venv/bin/activate` to activate the virtual environment, and `deactivate` to deactivate.
 
-5. Login by typing [`chalk login`](/cli/login). If you're using a dedicated environment, make sure you use the
-[`--api-host`](/cli/chalk#api-host) flag. Type `y` when prompted and login in the browser.
+5. Log in by typing [`chalk login`](/cli/login). If you're using a dedicated environment, make sure you use the
+[`--api-host`](/cli/chalk#api-host) flag. Type `y` when prompted and log in through the browser.
 
 6. Run [`chalk init`](/cli/init) to initialize your project files. This will initialize a directory structure with an
 empty `src` directory and three files: `chalk.yaml`, `README.md`, and `requirements.txt`.
@@ -86,7 +86,7 @@ which we will build in the next step.
 Having set up a basic project directory, next we'll want to configure the data sources from which we will load data to
 compute our features. We can do so in the Chalk dashboard.
 
-1. In the same directory from before, login or sign up with Chalk directly from the command line. The
+1. In the same directory from before, log in or sign up with Chalk directly from the command line. The
 [`chalk login`](/cli/login) command will open your browser and create an
 API token for your local development, as well as redirect you to your dashboard. If you are not
 redirected you can also find the dashboard at [https://chalk.ai/projects](https://chalk.ai/projects)

--- a/snowflake-deployment.mdx
+++ b/snowflake-deployment.mdx
@@ -86,7 +86,7 @@ Please share:
 
 - The `USER_NAME` and `PASSWORD` with us securely via an encrypted message following [using GPG](/docs/public-key).
 - The `WAREHOUSE_NAME`, `DB_NAME`, `SCHEMA_NAME`, and `ROLE_NAME` so that we can configure the Chalk platform to use them.
-- Your Snowflake account name (`select current_account_name();`) and organziation name (`select current_organization_name();`).
+- Your Snowflake account name (`select current_account_name();`) and organization name (`select current_organization_name();`).
 
 ---
 


### PR DESCRIPTION
After forking the docs for my last PR I figured I'd do a quick linting of them using [Vale](https://vale.sh). I turned up a dozen or so teeeeeeeny little spelling errors. These are the smallest nits possible. Most are about proper names or some incredibly minor typo. Figured I'd patch them while I keep reading the docs!
 