### PR TITLE
Docs: more nit squashing

### DIFF
--- a/aws-codeartifact.mdx
+++ b/aws-codeartifact.mdx
@@ -21,7 +21,7 @@ in your team's settings page. The principal will look like this:
 arn:aws:iam::***********:role/chalk-*********
 ```
 
-Once you have the IAM prinicpal ARN, you will need to grant the following permissions to the principal:
+Once you have the IAM principal ARN, you will need to grant the following permissions to the principal:
 
 ```
 codeartifact:DescribePackageVersion

--- a/branches.mdx
+++ b/branches.mdx
@@ -58,7 +58,7 @@ def new_resolver(name: NewFeatures.name) -> NewFeatures.greeting:
 
 As you adjust features and resolvers, you can iteratively see how your changes affect the your feature values with the [`Dataset.recompute`](/api-docs#Dataset.recompute) method. Just pass any features you want to be re-computed as arguments to the `features` parameter, and Chalk will generate a new Dataset revision using the latest definitions of features and resolvers.
 
-When used in conjunction with the ability to adjust your features and resolvers in the notebook, this tool allows developers and data scientists to rapidly experiement and productionize their work.
+When used in conjunction with the ability to adjust your features and resolvers in the notebook, this tool allows developers and data scientists to rapidly experiment and productionize their work.
 
 ---
 

--- a/customer-cloud-auth.mdx
+++ b/customer-cloud-auth.mdx
@@ -9,8 +9,7 @@ description: Configure SAML and OIDC providers for Chalk
 Before configuring SAML, please ensure that you have the information for configuring your SAML provider.
 For Okta, please view [this documentation](/docs/okta-saml).
 
-To configure SAML for your Chalk deployment, you will need to add the following information to your
-your `values.yaml`:
+To configure SAML for your Chalk deployment, you will need to add the following information to your `values.yaml`:
 
 ```
 chalk:
@@ -36,8 +35,7 @@ secret object.
 
 ## OIDC Configuration
 
-To configure OIDC for your Chalk deployment, you will need to add the following information to your
-your `values.yaml`:
+To configure OIDC for your Chalk deployment, you will need to add the following information to your`values.yaml`:
 
 ```
 chalk:

--- a/customer-cloud-auth.mdx
+++ b/customer-cloud-auth.mdx
@@ -35,7 +35,7 @@ secret object.
 
 ## OIDC Configuration
 
-To configure OIDC for your Chalk deployment, you will need to add the following information to your`values.yaml`:
+To configure OIDC for your Chalk deployment, you will need to add the following information to your `values.yaml`:
 
 ```
 chalk:

--- a/fraud-tutorial.mdx
+++ b/fraud-tutorial.mdx
@@ -126,7 +126,7 @@ class User:
 In our features above, we've added some comments and
 annotations to our features. These are optional, but
 can be useful for documentation and for setting alerting
-policies. For example, you may wish to send [Pagerduty alerts](/docs/pagerduty)
+policies. For example, you may wish to send [PagerDuty alerts](/docs/pagerduty)
 to [different teams](/docs/alertconfig) based on
 the owner of the related feature.
 

--- a/metrics-installation.mdx
+++ b/metrics-installation.mdx
@@ -63,9 +63,9 @@ The following is an example configuration for a metrics database:
 
 ## Database Routing Between Clusters
 In order for Chalk to properly function, all metrics databases must be routable from the Chalk Metadata Server.
-For metrics servers in the same cluster as the metadata server this is trivial, as all the kubernetes services are
+For metrics servers in the same cluster as the metadata server this is trivial, as all the Kubernetes services are
 easily accessed, and no special considerations are needed. For a metrics database in a different cluster, the `service-type`
-must be set to `load-balancer` in order to get a dns name that will route into the cluster. Routing can then be done in one of
+must be set to `load-balancer` in order to get a DNS name that will route into the cluster. Routing can then be done in one of
 two ways:
 1. Set `internal` to `false`, so that the clusters can route together over the open internet. For this to work, you
    must have public subnets attached to your VPC and an internet gateway etc.
@@ -76,7 +76,7 @@ Note that if the clusters are in the same VPC, simply setting the `service-type`
 <AttributeTable>
 <Attribute field={'timescale_image'} kind={'string'}>
 The docker image to use for the metrics database.
-This must be a postgres image with the Timescale plugin installed.
+This must be a Postgres image with the Timescale plugin installed.
 </Attribute>
 <Attribute field={'database_name'} kind={'string'}>
 The name of the database to create.

--- a/notebook-development.mdx
+++ b/notebook-development.mdx
@@ -128,7 +128,7 @@ FROM authorizations
 Chalk lines up the names of your target SQL columns with the names of your features.
 In this case, we have an `Authorization` feature class that contains a features called `authorized_at`.
 However, our Snowflake table has a column called `created_at` that we want to use to populate the `authorized_at` feature.
-So, we use the `as` keyword to rename the column in our resolver.
+We therefore use the `as` keyword to rename the column in our resolver.
 
 ## Inline Syntax
 

--- a/query-offline.mdx
+++ b/query-offline.mdx
@@ -73,7 +73,7 @@ input={
 
 ### Input times
 
-Timestamps can be be passed in the [input_times](/api-docs#ChalkClient.offline_query.input_times) argument.
+Timestamps can be passed in the [input_times](/api-docs#ChalkClient.offline_query.input_times) argument.
 If none are provided, Chalk will use the current time.
 
 ```py

--- a/reverse-etl.mdx
+++ b/reverse-etl.mdx
@@ -12,7 +12,7 @@ our data warehouse is the offline data store
 ([Timescale](https://timescale.com) or [BigQuery](https://cloud.google.com/bigquery/docs/))
 and our operational system is the online data store
 ([Redis](https://redis.com), [Cloud Memorystore](https://cloud.google.com/memorystore), or [DynamoDB](https://aws.amazon.com/dynamodb/)).
-The online data store is queried by
+Chalk's API client can be used to query the [online data store](/docs/query-basics) and the [offline data store](/docs/query-offline).
 one our [API clients](/docs/query-basics),
 while the offline data store queried by
 our [bulk API](/docs/query-offline).

--- a/reverse-etl.mdx
+++ b/reverse-etl.mdx
@@ -13,7 +13,7 @@ our data warehouse is the offline data store
 and our operational system is the online data store
 ([Redis](https://redis.com), [Cloud Memorystore](https://cloud.google.com/memorystore), or [DynamoDB](https://aws.amazon.com/dynamodb/)).
 The online data store is queried by
-one our our [API clients](/docs/query-basics),
+one our [API clients](/docs/query-basics),
 while the offline data store queried by
 our [bulk API](/docs/query-offline).
 


### PR DESCRIPTION
Just squashing some more nits.

I was thinking about making a PR to add a Vale-based GH action to catch a lot of these automatically. It is non-blocking and outputs a review to the PR. I could do that next.

I've also been limiting my PRs to small and unambiguous error-corrections. But there are a lot of subjective changes that could lead to better documentation. 

- For instance, the use of the words `easy, easily, simple, and simply` are abundant. These are generally avoided so as not to condescend to the reader (who may not find such topics easy or simple). A great number of sentences also start with `So,...`, which is also best avoided. Relatedly, the use of the formal ellipsis character should replace most `...` appearances outside of code blocks.
- Also, adding a Vale GH action is nice because you can build your own house style. There is, for instance, a lot of inconsistency here in the spelling of postgres/Postgres/PostgreSQL. I tried to grab a bunch in this PR. But Vale is a good tool for automatically enforcing that kind of consistency.