### PR TITLE
docs: update resolver-input and resolver-output links

### DIFF
--- a/has-one.mdx
+++ b/has-one.mdx
@@ -92,7 +92,7 @@ To define optional relationships, use the `typing.Optional[...]` keyword:
 <PyDiffEditor html={hasOneOptionalDiff} />
 
 Note, resolvers that take optional features as inputs need to handle the `None` case. This is
-covered in more detail in [the resolver's section of the docs](/docs/resolver-inputs#optional-has-one).
+covered in more detail in [the resolver's section of the docs](/docs/python-resolvers#optional-has-one).
 
 ---
 

--- a/python-resolvers.mdx
+++ b/python-resolvers.mdx
@@ -18,7 +18,7 @@ declaring the dependencies on other features, as well as the output feature(s).
 To depend on features from a [feature class](/docs/features),
 label your resolver arguments with your features as the types.
 You can then use those arguments in the body of your resolver to
-compute your [output features](/docs/resolver-outputs).
+compute your [output features](/docs/python-resolvers#outputs).
 If you're running our [editor plugin](/docs/editor-setup),
 your editor will see the type of each variable as the type
 of the underlying scalar.

--- a/resolver-inputs.mdx
+++ b/resolver-inputs.mdx
@@ -16,7 +16,7 @@ arguments to the resolver function.
 To depend on features from a [feature class](/docs/features),
 label your resolver arguments with your features as the types.
 You can then use those arguments in the body of your resolver to
-compute your [output features](/docs/resolver-outputs).
+compute your [output features](/docs/python-resolvers#outputs).
 If you're running our [editor plugin](/docs/editor-setup),
 your editor will see the type of each variable as the type
 of the underlying scalar.

--- a/resolver-overview.mdx
+++ b/resolver-overview.mdx
@@ -20,8 +20,8 @@ are computed.
 
 Resolvers have four main components: inputs, outputs, code, and run conditions.
 
-The first three of these are rather straightforward. The [**inputs**](/docs/resolver-inputs) to a resolver
-are the features it uses to compute its output. The [**outputs**](/docs/resolver-outputs) of a resolver
+The first three of these are rather straightforward. The [**inputs**](/docs/python-resolvers#inputs) to a resolver
+are the features it uses to compute its output. The [**outputs**](/docs/python-resolvers#outputs) of a resolver
 are the features that it computes. The code of the resolver is the logic that
 transforms your input features into your output features.
 

--- a/vector-search.mdx
+++ b/vector-search.mdx
@@ -80,7 +80,7 @@ class SearchQuery:
 
 ## Nearest neighbors as resolver inputs
 
-It's possible to use this relationship as a [has-many resolver input](/docs/resolver-inputs#has-many-dependencies). The resulting
+It's possible to use this relationship as a [has-many resolver input](/docs/python-resolvers#has-many-dependencies). The resulting
 documents will be returned as a [Chalk DataFrame](/docs/dataframe). Because the search is approximate, the number of
 documents to return *must* be specified via a slice expression.
 


### PR DESCRIPTION
migrating to docs/python-resolvers instead of docs/resolver-inputs and docs/resolver-outputs