### PR TITLE
remove mypy mention on the features overview page

### DIFF
--- a/features.mdx
+++ b/features.mdx
@@ -179,11 +179,6 @@ Note that all fields have a default `MISSING` value.
 Therefore, you can construct feature classes with any subset
 of the fields you would like to use.
 
-Chalk ships a [Mypy Plugin](/docs/editor-setup) that helps with
-many of the types in the Chalk package, including to check that
-`FeatureSets` are constructed
-[only with features](/docs/editor-setup#feature-value-type-checking)
-available on the class.
 
 ## Refactoring
 


### PR DESCRIPTION
Remove mypy mention on the features overview page

Original view:
<img width="3642" height="1164" alt="image" src="https://github.com/user-attachments/assets/94a6db49-fce3-47ef-a5fa-a3d1996110e5" />

Proposed change:
<img width="3622" height="1164" alt="image" src="https://github.com/user-attachments/assets/7a909345-75b6-4703-a9c4-5fd963b5f5c0" />
