### PR TITLE
remove small typo

### DIFF
--- a/materialized_aggregations.mdx
+++ b/materialized_aggregations.mdx
@@ -227,7 +227,7 @@ Now `backfill_schedule` has been set, the `total_transaction_amount` feature wil
 
 In addition to backfilling your aggregation with the recurring batch job, you can also integrate fresh data into your
 windowed aggregation with continuous backfills.
-Continuous backfills can be configured by supplying a [Duration](/api-docs#Duration)] to the `continuous_buffer_duration` e.g. `"36h"`.
+Continuous backfills can be configured by supplying a [Duration](/api-docs#Duration) to the `continuous_buffer_duration` e.g. `"36h"`.
 Chalk will compute data within your `continuous_buffer_duration` directly from your online resolvers.
 
 <TipInfo>Note: Chalk includes all the data contained in overlapping buckets.


### PR DESCRIPTION
Removed extra bracket from https://docs.chalk.ai/docs/materialized_aggregations#continuous-buffer

Original:
<img width="859" height="347" alt="image" src="https://github.com/user-attachments/assets/f722b294-ab24-4264-b185-97755ef52fb7" />

Proposed Change:
<img width="859" height="347" alt="image" src="https://github.com/user-attachments/assets/cf53a363-fccb-4595-9e8c-0c28ab45d5ed" />
