### PR TITLE
Specify PKCS#8 key format for Snowflake private key generation

### DIFF
--- a/snowflake-deployment.mdx
+++ b/snowflake-deployment.mdx
@@ -28,8 +28,19 @@ has `OWNER` on the database.
 
 ### Step 0: Generate Key Pair
 
-Follow the [Snowflake key-pair authentication guide](https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys)
-to generate your private and public keys.
+Generate a private key in **PKCS#8 format without encryption**. Other key formats are not currently supported.
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+```
+
+Then generate the corresponding public key:
+
+```bash
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+For more details, see the [Snowflake key-pair authentication guide](https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys).
 
 ### Step 1: Create Database Objects
 

--- a/snowflake-gcp-deployment.mdx
+++ b/snowflake-gcp-deployment.mdx
@@ -20,8 +20,19 @@ has `OWNER` on the database.
 
 ### Step 0: Generate Key Pair
 
-Follow the [Snowflake key-pair authentication guide](https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys)
-to generate your private and public keys.
+Generate a private key in **PKCS#8 format without encryption**. Other key formats are not currently supported.
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+```
+
+Then generate the corresponding public key:
+
+```bash
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+For more details, see the [Snowflake key-pair authentication guide](https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys).
 
 ### Step 1: Create Database Objects
 


### PR DESCRIPTION
Snowflake key-pair auth requires PKCS#8 unencrypted keys. Update the "Generate Key Pair" step in both AWS and GCP deployment guides with the explicit openssl command and a note that other formats are not supported.